### PR TITLE
Added keys to the passthrough switch

### DIFF
--- a/frame_rebuilder.nk
+++ b/frame_rebuilder.nk
@@ -1,27 +1,31 @@
+set cut_paste_input [stack 0]
+version 9.0 v6
+push $cut_paste_input
 Group {
  name rebuild_frames
  selected true
- xpos -1185
- ypos 108
+ xpos -1445
+ ypos 859
  addUserKnob {20 User}
  addUserKnob {26 text1 l "" +STARTLINE T "1) Hit 'Reset' before beginning"}
  addUserKnob {22 reset l Reset T "n = nuke.thisNode()\['inputframe']\nkt = nuke.thisNode()\['kt']\nko = nuke.thisNode()\['ko']\np = nuke.thisNode()\['passthrough']\nn.clearAnimated()\nkt.clearAnimated()\nko.clearAnimated()\nn.setAnimated()\nf = nuke.thisNode().firstFrame()\nl = nuke.thisNode().lastFrame() \nn.animation(0).setKey(f,f)\nn.animation(0).setKey(l,l)\np.setValue(0)" +STARTLINE}
  addUserKnob {26 ""}
  addUserKnob {26 text2 l "" +STARTLINE T "2) Add keys on frames that are good\n    Remove keys on frames to be rebuilt "}
  addUserKnob {3 inputframe l Frame}
- inputframe 232
+ inputframe {0}
  addUserKnob {22 addkey l "Add Key" -STARTLINE T "n = nuke.thisNode()\['inputframe']\nn.setAnimated()\nt = nuke.frame()\nn.animation(0).setKey(t,t)\n"}
  addUserKnob {22 deletekey l "Delete key" -STARTLINE T "n = nuke.thisNode()\['inputframe']\nt = nuke.frame()\n#n.animation(0).removeKeyAt(t)\nn.removeKeyAt(t)"}
- addUserKnob {22 addall l "Keyframe all" T "n = nuke.thisNode()\['inputframe']\nn.setAnimated()\nf = nuke.thisNode().firstFrame()\nl = nuke.thisNode().lastFrame() \n\nn.animation(0).setKey(f,f)\nn.animation(0).setKey(l,l)\n\nfor i in xrange( f, l, 1 ):\n\tn.setValueAt(i, i)" +STARTLINE}
+ addUserKnob {22 addall l "Keyframe all" T "n = nuke.thisNode()\['inputframe']\np = nuke.thisNode()\['passthrough']\n\nn.setAnimated()\np.setAnimated()\n\nf = nuke.thisNode().firstFrame()\nl = nuke.thisNode().lastFrame() \n\nn.animation(0).setKey(f,f)\nn.animation(0).setKey(l,l)\n\nfor i in xrange( f, l, 1 ):\n\tn.setValueAt(i, i)\n\tp.setValueAt(1, i)\n" +STARTLINE}
  addUserKnob {26 text3 l "" +STARTLINE T "(Do not change value of 'Frame' - leave it as frame number)"}
  addUserKnob {26 ""}
  addUserKnob {3 kt l INVISIBLE +INVISIBLE}
- kt 375
+ kt {375}
  addUserKnob {3 ko l INVISIBLE +INVISIBLE}
- ko 129
+ ko {129}
  addUserKnob {3 passthrough l INVISIBLE +INVISIBLE}
+ passthrough {0}
  addUserKnob {26 text4 l "" +STARTLINE T "3) Hit 'Rebuild' to rebuild 'bad' frames"}
- addUserKnob {22 rebuild l Rebuild! T "k = nuke.thisNode()\['inputframe']\n\nif(k.isAnimated()):\n\t\t\t\n\ttOriginalCurve = k.animation(0)\n\t\t\t\t\n\ttKeys = tOriginalCurve.keys()\n\n\ti = 0\n\n\t\n\tkt = nuke.thisNode()\['kt']\n\n\tko  = nuke.thisNode()\['ko']\n\n\tkt.clearAnimated()\n\n\tko.clearAnimated()\n\n\tkt.setAnimated()\n\n\tko.setAnimated()\n\n\tfor tKey in tKeys:\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\n\t\ttFrame = tKey.x \n\t\ttFrameY = tKey.y\n\n\t\tprint(\"key \" + str(i) + \" has x value \" + str(tFrame) + \", y value \" + str(tFrameY))\n\n\t\tko.setValueAt( i, tFrame )\n\n\t\tkt.setValueAt( tFrame, i )\n\n\t\ti = i+1\n\n\tkoKeys = ko.animation(0).keys()\n\n\tfor tKey in koKeys:\t\n\n\t\ttKey.interpolation = nuke.LINEAR\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\n\t\t\n\tktKeys = kt.animation(0).keys()\n\n\tfor tKey in ktKeys:\t\n\n\t\ttKey.interpolation = nuke.LINEAR\n\np = nuke.thisNode()\['passthrough']\np.setValue(1)" +STARTLINE}
+ addUserKnob {22 rebuild l Rebuild! T "k = nuke.thisNode()\['inputframe']\np = nuke.thisNode()\['passthrough']\n\nif(k.isAnimated()):\n\t\t\t\n\ttOriginalCurve = k.animation(0)\n\t\t\t\t\n\ttKeys = tOriginalCurve.keys()\n\n\ti = 0\n\n\t\n\tkt = nuke.thisNode()\['kt']\n\n\tko  = nuke.thisNode()\['ko']\n\n\tkt.clearAnimated()\n\tko.clearAnimated()\n\n\tkt.setAnimated()\n\tko.setAnimated()\n\tp.setAnimated()\n\n\tfor tKey in tKeys:\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\n\t\ttFrame = tKey.x \n\t\ttFrameY = tKey.y\n\n\t\t#print(\"key \" + str(i) + \" has x value \" + str(tFrame) + \", y value \" + str(tFrameY))\n\t\tp.setValueAt( 0, tFrame )\n\n\t\tko.setValueAt( i, tFrame )\n\n\t\tkt.setValueAt( tFrame, i )\n\n\n\t\ti = i+1\n\n\tkoKeys = ko.animation(0).keys()\n\n\tfor tKey in koKeys:\n\n\t\ttKey.interpolation = nuke.LINEAR\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\n\t\t\n\tktKeys = kt.animation(0).keys()\n\n\tfor tKey in ktKeys:\n\n\t\ttKey.interpolation = nuke.LINEAR" +STARTLINE}
  addUserKnob {20 about l About}
  addUserKnob {26 credit l "" -STARTLINE T "Rebuilds broken or missing frames using an OFlow. \nAssumes that many of the frames are OK, but that bad frames are littered throughout. \n\nv1.0 by Richard Frazer"}
  addUserKnob {26 ""}
@@ -37,11 +41,11 @@ Group {
   xpos 509
   ypos -547
  }
-set N56b81e70 [stack 0]
+set N9d292800 [stack 0]
  TimeWarp {
   lookup {{parent.kt i}}
+  time ""
   name TimeWarp5
-  selected true
   xpos 475
   ypos -480
  }
@@ -69,7 +73,7 @@ set N56b81e70 [stack 0]
   xpos 475
   ypos -397
  }
-push $N56b81e70
+push $N9d292800
  Dot {
   name Dot2
   xpos 596
@@ -82,7 +86,7 @@ push $N56b81e70
  }
  Switch {
   inputs 2
-  which {{parent.passthrough}}
+  which {{parent.passthrough i}}
   name Switch1
   xpos 475
   ypos -287


### PR DESCRIPTION
I added keyframes to the "Switch" node at the end of the group so that it isn't reading the oflow node unless the frame is actually being rebuilt. I'm fairly new to python in Nuke and didn't thoroughly test this, but from what I can tell it works fine!
- Spencer
